### PR TITLE
add fix for java.lang.ClassNotFoundException: org.apache.commons.codecc.binary.Base64 when adding schema as "https"

### DIFF
--- a/component/pom.xml
+++ b/component/pom.xml
@@ -247,7 +247,8 @@
                             org.apache.lucene.*,
                             org.apache.logging.log4j.*,
                             org.joda.time.*,
-                            com.carrotsearch.hppc.*
+                            com.carrotsearch.hppc.*,
+                            org.apache.commons.codec.*,
                         </Private-Package>
                         <Export-Package>
                             org.wso2.extension.siddhi.store.elasticsearch,


### PR DESCRIPTION
## Purpose
> $subject

## Goals
> publish data to elasticsearch https endpoint

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? yes
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes