### PR TITLE
Add index type via parameter on annotation

### DIFF
--- a/component/src/main/java/org/wso2/extension/siddhi/store/elasticsearch/ElasticsearchRecordIterator.java
+++ b/component/src/main/java/org/wso2/extension/siddhi/store/elasticsearch/ElasticsearchRecordIterator.java
@@ -27,7 +27,6 @@ import org.elasticsearch.index.query.QueryStringQueryBuilder;
 import org.elasticsearch.search.SearchHit;
 import org.elasticsearch.search.builder.SearchSourceBuilder;
 import org.wso2.extension.siddhi.store.elasticsearch.exceptions.ElasticsearchServiceException;
-import org.wso2.extension.siddhi.store.elasticsearch.utils.ElasticsearchTableConstants;
 import org.wso2.siddhi.core.table.record.RecordIterator;
 import org.wso2.siddhi.query.api.definition.Attribute;
 
@@ -44,13 +43,13 @@ public class ElasticsearchRecordIterator implements RecordIterator<Object[]> {
     private List<Attribute> attributes;
     private Iterator<SearchHit> elasticsearchHitsIterator;
 
-    public ElasticsearchRecordIterator(String indexName, String queryString, RestHighLevelClient restHighLevelClient,
-                                       List<Attribute> attributes)
+    public ElasticsearchRecordIterator(String indexName, String indexType, String queryString, 
+                                       RestHighLevelClient restHighLevelClient, List<Attribute> attributes)
             throws ElasticsearchServiceException {
         this.attributes = attributes;
         QueryBuilder queryBuilder = getQueryBuilder(queryString);
         SearchRequest searchRequest = new SearchRequest(indexName);
-        searchRequest.types(ElasticsearchTableConstants.ELASTICSEARCH_INDEX_TYPE);
+        searchRequest.types(indexType);
         SearchSourceBuilder searchSourceBuilder = new SearchSourceBuilder();
         searchSourceBuilder.query(queryBuilder);
         searchRequest.source(searchSourceBuilder);

--- a/component/src/main/java/org/wso2/extension/siddhi/store/elasticsearch/utils/ElasticsearchTableConstants.java
+++ b/component/src/main/java/org/wso2/extension/siddhi/store/elasticsearch/utils/ElasticsearchTableConstants.java
@@ -32,6 +32,7 @@ public class ElasticsearchTableConstants {
     public static final String ANNOTATION_ELEMENT_INDEX_NUMBER_OF_SHARDS = "index.number.of.shards";
     public static final String ANNOTATION_ELEMENT_INDEX_NUMBER_OF_REPLICAS = "index.number.of.replicas";
     public static final String ANNOTATION_ELEMENT_INDEX_ALIAS = "index.alias";
+    public static final String ANNOTATION_ELEMENT_INDEX_TYPE = "index.type";
     public static final String ANNOTATION_ELEMENT_UPDATE_BATCH_SIZE = "update.batch.size";
     public static final String ANNOTATION_ELEMENT_BULK_ACTIONS = "bulk.actions";
     public static final String ANNOTATION_ELEMENT_BULK_SIZE = "bulk.size";
@@ -48,6 +49,7 @@ public class ElasticsearchTableConstants {
     public static final String ANNOTATION_ELEMENT_MEMBER_LIST = "elasticsearch.member.list";
 
     public static final String DEFAULT_HOSTNAME = "localhost";
+    public static final String DEFAULT_INDEX_TYPE = "_doc";
     public static final int DEFAULT_PORT = 9200;
     public static final int DEFAULT_NUMBER_OF_SHARDS = 3;
     public static final int DEFAULT_NUMBER_OF_REPLICAS = 2;
@@ -73,5 +75,4 @@ public class ElasticsearchTableConstants {
     public static final String MAPPING_PROPERTIES_ELEMENT = "properties";
     public static final String MAPPING_TYPE_ELEMENT = "type";
 
-    public static final String ELASTICSEARCH_INDEX_TYPE = "_doc";
 }

--- a/docs/api/latest.md
+++ b/docs/api/latest.md
@@ -1,4 +1,4 @@
-# API Docs - v1.1.3
+# API Docs - v1.1.4-SNAPSHOT
 
 ## Store
 
@@ -8,7 +8,7 @@
 
 <span id="syntax" class="md-typeset" style="display: block; font-weight: bold;">Syntax</span>
 ```
-@Store(type="elasticsearch", hostname="<STRING>", port="<INT>", scheme="<STRING>", elasticsearch.member.list="<STRING>", username="<STRING>", password="<STRING>", index.name="<STRING>", payload.index.of.index.name="<INT>", index.alias="<STRING>", index.number.of.shards="<INT>", index.number.of.replicas="<INT>", bulk.actions="<INT>", bulk.size="<LONG>", concurrent.requests="<INT>", flush.interval="<LONG>", backoff.policy.retry.no="<INT>", backoff.policy.wait.time="<LONG>", ssl.enabled="<BOOL>", trust.store.type="<STRING>", trust.store.path="<STRING>", trust.store.pass="<STRING>")
+@Store(type="elasticsearch", hostname="<STRING>", port="<INT>", scheme="<STRING>", elasticsearch.member.list="<STRING>", username="<STRING>", password="<STRING>", index.name="<STRING>", index.type="<STRING>", payload.index.of.index.name="<INT>", index.alias="<STRING>", index.number.of.shards="<INT>", index.number.of.replicas="<INT>", bulk.actions="<INT>", bulk.size="<LONG>", concurrent.requests="<INT>", flush.interval="<LONG>", backoff.policy.retry.no="<INT>", backoff.policy.wait.time="<LONG>", ssl.enabled="<BOOL>", trust.store.type="<STRING>", trust.store.path="<STRING>", trust.store.pass="<STRING>")
 @PrimaryKey("PRIMARY_KEY")
 @Index("INDEX")
 ```
@@ -75,6 +75,14 @@
         <td style="vertical-align: top">index.name</td>
         <td style="vertical-align: top; word-wrap: break-word">The name of the Elasticsearch index.</td>
         <td style="vertical-align: top">The table name defined in the Siddhi App query.</td>
+        <td style="vertical-align: top">STRING</td>
+        <td style="vertical-align: top">Yes</td>
+        <td style="vertical-align: top">No</td>
+    </tr>
+    <tr>
+        <td style="vertical-align: top">index.type</td>
+        <td style="vertical-align: top; word-wrap: break-word">The the type of the index.</td>
+        <td style="vertical-align: top">_doc</td>
         <td style="vertical-align: top">STRING</td>
         <td style="vertical-align: top">Yes</td>
         <td style="vertical-align: top">No</td>


### PR DESCRIPTION
## Purpose
> Add index type via parameter on annotations

## Goals
> If there are many types on the same index, this feature can put a custom type saving streams

