### PR TITLE
Add support for configuring timeout values for index and document-related requests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,12 @@
 
 # virtual machine crash logs, see http://www.java.com/en/download/help/error_hotspot.xml
 hs_err_pid*
+
+# Build files
+target
+
+# Code editor
+.idea
+
+# OS
+.DS_Store

--- a/component/pom.xml
+++ b/component/pom.xml
@@ -1,21 +1,22 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2018, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+  ~ Copyright (c) 2024, WSO2 LLC. (http://www.wso2.com).
   ~
-  ~ WSO2 Inc. licenses this file to you under the Apache License,
+  ~ WSO2 LLC. licenses this file to you under the Apache License,
   ~ Version 2.0 (the "License"); you may not use this file except
   ~ in compliance with the License.
   ~ You may obtain a copy of the License at
   ~
-  ~      http://www.apache.org/licenses/LICENSE-2.0
+  ~ http://www.apache.org/licenses/LICENSE-2.0
   ~
   ~ Unless required by applicable law or agreed to in writing,
   ~ software distributed under the License is distributed on an
   ~ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
-  ~ KIND, either express or implied. See the License for the
+  ~ KIND, either express or implied.  See the License for the
   ~ specific language governing permissions and limitations
   ~ under the License.
   -->
+
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <parent>
         <groupId>org.wso2.extension.siddhi.store.elasticsearch</groupId>

--- a/component/pom.xml
+++ b/component/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>org.wso2.extension.siddhi.store.elasticsearch</groupId>
         <artifactId>siddhi-store-elasticsearch-parent</artifactId>
-        <version>2.1.1</version>
+        <version>2.1.2-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>siddhi-store-elasticsearch</artifactId>
@@ -44,8 +44,16 @@
             <artifactId>siddhi-query-api</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.apache.log4j.wso2</groupId>
-            <artifactId>log4j</artifactId>
+            <groupId>org.apache.logging.log4j</groupId>
+            <artifactId>log4j-api</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.logging.log4j</groupId>
+            <artifactId>log4j-core</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.logging.log4j</groupId>
+            <artifactId>log4j-to-slf4j</artifactId>
         </dependency>
         <dependency>
             <groupId>org.testng</groupId>

--- a/component/src/main/java/org/wso2/extension/siddhi/store/elasticsearch/ElasticsearchEventTable.java
+++ b/component/src/main/java/org/wso2/extension/siddhi/store/elasticsearch/ElasticsearchEventTable.java
@@ -519,8 +519,7 @@ public class ElasticsearchEventTable extends AbstractRecordTable {
                     storeAnnotation.getElement(ANNOTATION_ELEMENT_INDEX_REQUEST_TIMEOUT))) {
                 indexRequestTimeout =
                         Long.parseLong(storeAnnotation.getElement(ANNOTATION_ELEMENT_INDEX_REQUEST_TIMEOUT));
-            } else if (!ElasticsearchTableUtils.isEmpty(
-                    configReader.readConfig(ANNOTATION_ELEMENT_INDEX_REQUEST_TIMEOUT, null))) {
+            } else {
                 indexRequestTimeout =
                         Long.parseLong(configReader.readConfig(ANNOTATION_ELEMENT_INDEX_REQUEST_TIMEOUT,
                                 String.valueOf(indexRequestTimeout)));

--- a/component/src/main/java/org/wso2/extension/siddhi/store/elasticsearch/ElasticsearchEventTable.java
+++ b/component/src/main/java/org/wso2/extension/siddhi/store/elasticsearch/ElasticsearchEventTable.java
@@ -1,20 +1,21 @@
 /*
- * Copyright (c) 2018-2024, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ * Copyright (c) 2024, WSO2 LLC. (http://www.wso2.com).
  *
- * WSO2 Inc. licenses this file to you under the Apache License,
+ * WSO2 LLC. licenses this file to you under the Apache License,
  * Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ * http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
- * KIND, either express or implied. See the License for the
+ * KIND, either express or implied.  See the License for the
  * specific language governing permissions and limitations
  * under the License.
  */
+
 package org.wso2.extension.siddhi.store.elasticsearch;
 
 import org.apache.http.HttpHost;

--- a/component/src/main/java/org/wso2/extension/siddhi/store/elasticsearch/ElasticsearchEventTable.java
+++ b/component/src/main/java/org/wso2/extension/siddhi/store/elasticsearch/ElasticsearchEventTable.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ * Copyright (c) 2018-2024, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
  *
  * WSO2 Inc. licenses this file to you under the Apache License,
  * Version 2.0 (the "License"); you may not use this file except
@@ -91,6 +91,8 @@ import static org.wso2.extension.siddhi.store.elasticsearch.utils.ElasticsearchT
 import static org.wso2.extension.siddhi.store.elasticsearch.utils.ElasticsearchTableConstants.
         ANNOTATION_ELEMENT_BULK_ACTIONS;
 import static org.wso2.extension.siddhi.store.elasticsearch.utils.ElasticsearchTableConstants.
+        ANNOTATION_ELEMENT_BULK_REQUEST_TIMEOUT;
+import static org.wso2.extension.siddhi.store.elasticsearch.utils.ElasticsearchTableConstants.
         ANNOTATION_ELEMENT_BULK_SIZE;
 import static org.wso2.extension.siddhi.store.elasticsearch.utils.ElasticsearchTableConstants.
         ANNOTATION_ELEMENT_CLIENT_IO_THREAD_COUNT;
@@ -108,6 +110,10 @@ import static org.wso2.extension.siddhi.store.elasticsearch.utils.ElasticsearchT
         ANNOTATION_ELEMENT_INDEX_NUMBER_OF_REPLICAS;
 import static org.wso2.extension.siddhi.store.elasticsearch.utils.ElasticsearchTableConstants.
         ANNOTATION_ELEMENT_INDEX_NUMBER_OF_SHARDS;
+import static org.wso2.extension.siddhi.store.elasticsearch.utils.ElasticsearchTableConstants.
+        ANNOTATION_ELEMENT_INDEX_REQUEST_MASTER_TIMEOUT;
+import static org.wso2.extension.siddhi.store.elasticsearch.utils.ElasticsearchTableConstants.
+        ANNOTATION_ELEMENT_INDEX_REQUEST_TIMEOUT;
 import static org.wso2.extension.siddhi.store.elasticsearch.utils.ElasticsearchTableConstants.
         ANNOTATION_ELEMENT_MEMBER_LIST;
 import static org.wso2.extension.siddhi.store.elasticsearch.utils.ElasticsearchTableConstants.
@@ -133,11 +139,14 @@ import static org.wso2.extension.siddhi.store.elasticsearch.utils.ElasticsearchT
 import static org.wso2.extension.siddhi.store.elasticsearch.utils.ElasticsearchTableConstants.
         DEFAULT_BACKOFF_POLICY_WAIT_TIME;
 import static org.wso2.extension.siddhi.store.elasticsearch.utils.ElasticsearchTableConstants.DEFAULT_BULK_ACTIONS;
+import static org.wso2.extension.siddhi.store.elasticsearch.utils.ElasticsearchTableConstants.DEFAULT_BULK_REQUEST_TIMEOUT;
 import static org.wso2.extension.siddhi.store.elasticsearch.utils.ElasticsearchTableConstants.DEFAULT_BULK_SIZE_IN_MB;
 import static org.wso2.extension.siddhi.store.elasticsearch.utils.ElasticsearchTableConstants.
         DEFAULT_CONCURRENT_REQUESTS;
 import static org.wso2.extension.siddhi.store.elasticsearch.utils.ElasticsearchTableConstants.DEFAULT_FLUSH_INTERVAL;
 import static org.wso2.extension.siddhi.store.elasticsearch.utils.ElasticsearchTableConstants.DEFAULT_HOSTNAME;
+import static org.wso2.extension.siddhi.store.elasticsearch.utils.ElasticsearchTableConstants.DEFAULT_INDEX_REQUEST_MASTER_TIMEOUT;
+import static org.wso2.extension.siddhi.store.elasticsearch.utils.ElasticsearchTableConstants.DEFAULT_INDEX_REQUEST_TIMEOUT;
 import static org.wso2.extension.siddhi.store.elasticsearch.utils.ElasticsearchTableConstants.DEFAULT_IO_THREAD_COUNT;
 import static org.wso2.extension.siddhi.store.elasticsearch.utils.ElasticsearchTableConstants.
         DEFAULT_NUMBER_OF_REPLICAS;
@@ -250,7 +259,20 @@ import static org.wso2.extension.siddhi.store.elasticsearch.utils.ElasticsearchT
                 @Parameter(name = "trust.store.pass",
                         description = "Trust store password.",
                         type = {DataType.STRING}, optional = true,
-                        defaultValue = "wso2carbon")
+                        defaultValue = "wso2carbon"),
+                @Parameter(name = "index.request.timeout",
+                        description = "Timeout to wait for the all the nodes to " +
+                                "acknowledge the index-related operations in seconds.",
+                        type = {DataType.LONG}, optional = true,
+                        defaultValue = "null"),
+                @Parameter(name = "index.request.master.timeout",
+                        description = "Timeout to connect to the master node for index-related operations in seconds.",
+                        type = {DataType.LONG}, optional = true,
+                        defaultValue = "null"),
+                @Parameter(name = "bulk.request.timeout",
+                        description = "Timeout to wait for the bulk request to be performed in seconds.",
+                        type = {DataType.LONG}, optional = true,
+                        defaultValue = "null")
         },
 
         examples = {
@@ -328,6 +350,9 @@ public class ElasticsearchEventTable extends AbstractRecordTable {
     private int payloadIndexOfIndexName = DEFAULT_PAYLOAD_INDEX_OF_INDEX_NAME;
     private String listOfHostnames;
     private Map<String, String> typeMappings = new HashMap<>();
+    private long indexRequestTimeout = DEFAULT_INDEX_REQUEST_TIMEOUT;
+    private long indexRequestMasterTimeout = DEFAULT_INDEX_REQUEST_MASTER_TIMEOUT;
+    private long bulkRequestTimeout = DEFAULT_BULK_REQUEST_TIMEOUT;
 
     /**
      * Initializing the Record Table
@@ -489,6 +514,35 @@ public class ElasticsearchEventTable extends AbstractRecordTable {
                     typeMappings.put(element.getKey(), element.getValue());
                 }
             }
+
+            if (!ElasticsearchTableUtils.isEmpty(
+                    storeAnnotation.getElement(ANNOTATION_ELEMENT_INDEX_REQUEST_TIMEOUT))) {
+                indexRequestTimeout =
+                        Long.parseLong(storeAnnotation.getElement(ANNOTATION_ELEMENT_INDEX_REQUEST_TIMEOUT));
+            } else if (!ElasticsearchTableUtils.isEmpty(
+                    configReader.readConfig(ANNOTATION_ELEMENT_INDEX_REQUEST_TIMEOUT, null))) {
+                indexRequestTimeout =
+                        Long.parseLong(configReader.readConfig(ANNOTATION_ELEMENT_INDEX_REQUEST_TIMEOUT,
+                                String.valueOf(indexRequestTimeout)));
+            }
+            if (!ElasticsearchTableUtils.isEmpty(
+                    storeAnnotation.getElement(ANNOTATION_ELEMENT_INDEX_REQUEST_MASTER_TIMEOUT))) {
+                indexRequestMasterTimeout =
+                        Long.parseLong(storeAnnotation.getElement(ANNOTATION_ELEMENT_INDEX_REQUEST_MASTER_TIMEOUT));
+            } else {
+                indexRequestMasterTimeout =
+                        Long.parseLong(configReader.readConfig(ANNOTATION_ELEMENT_INDEX_REQUEST_MASTER_TIMEOUT,
+                                String.valueOf(indexRequestMasterTimeout)));
+            }
+            if (!ElasticsearchTableUtils.isEmpty(
+                    storeAnnotation.getElement(ANNOTATION_ELEMENT_BULK_REQUEST_TIMEOUT))) {
+                bulkRequestTimeout =
+                        Long.parseLong(storeAnnotation.getElement(ANNOTATION_ELEMENT_BULK_REQUEST_TIMEOUT));
+            } else {
+                bulkRequestTimeout =
+                        Long.parseLong(configReader.readConfig(ANNOTATION_ELEMENT_BULK_REQUEST_TIMEOUT,
+                                String.valueOf(bulkRequestTimeout)));
+            }
         } else {
             throw new ElasticsearchEventTableException("Elasticsearch Store annotation list null for table id : '" +
                     tableDefinition.getId() + "', required properties cannot be resolved.");
@@ -557,7 +611,7 @@ public class ElasticsearchEventTable extends AbstractRecordTable {
         BulkProcessor.Builder bulkProcessorBuilder = BulkProcessor.builder(
                 (request, bulkListener) ->
                         restHighLevelClient.bulkAsync(request, RequestOptions.DEFAULT, bulkListener),
-                new BulkProcessorListener());
+                new BulkProcessorListener(bulkRequestTimeout));
         bulkProcessorBuilder.setBulkActions(bulkActions);
         bulkProcessorBuilder.setBulkSize(new ByteSizeValue(bulkSize, ByteSizeUnit.MB));
         bulkProcessorBuilder.setConcurrentRequests(concurrentRequests);
@@ -571,9 +625,16 @@ public class ElasticsearchEventTable extends AbstractRecordTable {
     }
 
     static class BulkProcessorListener implements BulkProcessor.Listener {
+        private final long bulkRequestTimeout;
+
+        private BulkProcessorListener(long bulkRequestTimeout) {
+            this.bulkRequestTimeout = bulkRequestTimeout;
+        }
+
         @Override
         public void beforeBulk(long executionId, BulkRequest request) {
             int numberOfActions = request.numberOfActions();
+            request.timeout(TimeValue.timeValueSeconds(bulkRequestTimeout));
             logger.debug("Executing bulk [{" + executionId + "}] with {" + numberOfActions + "} requests");
         }
 
@@ -851,6 +912,8 @@ public class ElasticsearchEventTable extends AbstractRecordTable {
         }
 
         CreateIndexRequest request = new CreateIndexRequest(indexName);
+        request.setTimeout(TimeValue.timeValueSeconds(indexRequestTimeout));
+        request.setMasterTimeout(TimeValue.timeValueSeconds(indexRequestMasterTimeout));
         request.settings(Settings.builder()
                 .put(SETTING_INDEX_NUMBER_OF_SHARDS, numberOfShards)
                 .put(SETTING_INDEX_NUMBER_OF_REPLICAS, numberOfReplicas)

--- a/component/src/main/java/org/wso2/extension/siddhi/store/elasticsearch/ElasticsearchEventTable.java
+++ b/component/src/main/java/org/wso2/extension/siddhi/store/elasticsearch/ElasticsearchEventTable.java
@@ -265,15 +265,15 @@ import static org.wso2.extension.siddhi.store.elasticsearch.utils.ElasticsearchT
                         description = "Timeout to wait for the all the nodes to " +
                                 "acknowledge the index-related operations in seconds.",
                         type = {DataType.LONG}, optional = true,
-                        defaultValue = "null"),
+                        defaultValue = "30"),
                 @Parameter(name = "index.request.master.timeout",
                         description = "Timeout to connect to the master node for index-related operations in seconds.",
                         type = {DataType.LONG}, optional = true,
-                        defaultValue = "null"),
+                        defaultValue = "30"),
                 @Parameter(name = "bulk.request.timeout",
                         description = "Timeout to wait for the bulk request to be performed in seconds.",
                         type = {DataType.LONG}, optional = true,
-                        defaultValue = "null")
+                        defaultValue = "60")
         },
 
         examples = {

--- a/component/src/main/java/org/wso2/extension/siddhi/store/elasticsearch/utils/ElasticsearchTableConstants.java
+++ b/component/src/main/java/org/wso2/extension/siddhi/store/elasticsearch/utils/ElasticsearchTableConstants.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ * Copyright (c) 2018-2024, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
  *
  * WSO2 Inc. licenses this file to you under the Apache License,
  * Version 2.0 (the "License"); you may not use this file except

--- a/component/src/main/java/org/wso2/extension/siddhi/store/elasticsearch/utils/ElasticsearchTableConstants.java
+++ b/component/src/main/java/org/wso2/extension/siddhi/store/elasticsearch/utils/ElasticsearchTableConstants.java
@@ -47,6 +47,9 @@ public class ElasticsearchTableConstants {
     public static final String ANNOTATION_ELEMENT_PAYLOAD_INDEX_OF_INDEX_NAME = "payload.index.of.index.name";
     public static final String ANNOTATION_ELEMENT_MEMBER_LIST = "elasticsearch.member.list";
     public static final String ANNOTATION_TYPE_MAPPINGS = "TypeMappings";
+    public static final String ANNOTATION_ELEMENT_INDEX_REQUEST_TIMEOUT = "index.request.timeout";
+    public static final String ANNOTATION_ELEMENT_INDEX_REQUEST_MASTER_TIMEOUT = "index.request.master.timeout";
+    public static final String ANNOTATION_ELEMENT_BULK_REQUEST_TIMEOUT = "bulk.request.timeout";
 
     public static final String DEFAULT_HOSTNAME = "localhost";
     public static final int DEFAULT_PORT = 9200;
@@ -67,6 +70,9 @@ public class ElasticsearchTableConstants {
     public static final String DEFAULT_TRUSTSTORE_PASS = "wso2carbon";
     public static final String DEFAULT_TRUSTSTORE_TYPE = "jks";
     public static final int DEFAULT_PAYLOAD_INDEX_OF_INDEX_NAME = -1;
+    public static final long DEFAULT_INDEX_REQUEST_TIMEOUT = 30;
+    public static final long DEFAULT_INDEX_REQUEST_MASTER_TIMEOUT = 30;
+    public static final long DEFAULT_BULK_REQUEST_TIMEOUT = 60;
     public static final String SETTING_INDEX_NUMBER_OF_SHARDS = "index.number_of_shards";
     public static final String SETTING_INDEX_NUMBER_OF_REPLICAS = "index.number_of_replicas";
 

--- a/component/src/main/java/org/wso2/extension/siddhi/store/elasticsearch/utils/ElasticsearchTableConstants.java
+++ b/component/src/main/java/org/wso2/extension/siddhi/store/elasticsearch/utils/ElasticsearchTableConstants.java
@@ -1,17 +1,17 @@
 /*
- * Copyright (c) 2018-2024, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ * Copyright (c) 2024, WSO2 LLC. (http://www.wso2.com).
  *
- * WSO2 Inc. licenses this file to you under the Apache License,
+ * WSO2 LLC. licenses this file to you under the Apache License,
  * Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ * http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
- * KIND, either express or implied. See the License for the
+ * KIND, either express or implied.  See the License for the
  * specific language governing permissions and limitations
  * under the License.
  */

--- a/pom.xml
+++ b/pom.xml
@@ -1,21 +1,22 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2018-2024, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+  ~ Copyright (c) 2024, WSO2 LLC. (http://www.wso2.com).
   ~
-  ~ WSO2 Inc. licenses this file to you under the Apache License,
+  ~ WSO2 LLC. licenses this file to you under the Apache License,
   ~ Version 2.0 (the "License"); you may not use this file except
   ~ in compliance with the License.
   ~ You may obtain a copy of the License at
   ~
-  ~      http://www.apache.org/licenses/LICENSE-2.0
+  ~ http://www.apache.org/licenses/LICENSE-2.0
   ~
   ~ Unless required by applicable law or agreed to in writing,
   ~ software distributed under the License is distributed on an
   ~ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
-  ~ KIND, either express or implied. See the License for the
+  ~ KIND, either express or implied.  See the License for the
   ~ specific language governing permissions and limitations
   ~ under the License.
   -->
+
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <parent>
         <groupId>org.wso2</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2018, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+  ~ Copyright (c) 2018-2024, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
   ~
   ~ WSO2 Inc. licenses this file to you under the Apache License,
   ~ Version 2.0 (the "License"); you may not use this file except
@@ -26,7 +26,7 @@
     <packaging>pom</packaging>
     <groupId>org.wso2.extension.siddhi.store.elasticsearch</groupId>
     <artifactId>siddhi-store-elasticsearch-parent</artifactId>
-    <version>2.1.1</version>
+    <version>2.1.2-SNAPSHOT</version>
     <name>Siddhi Extension - Elasticsearch Store</name>
     <profiles>
         <profile>
@@ -62,27 +62,19 @@
                 <version>${siddhi.version}</version>
             </dependency>
             <dependency>
-                <groupId>org.apache.log4j.wso2</groupId>
-                <artifactId>log4j</artifactId>
+                <groupId>org.apache.logging.log4j</groupId>
+                <artifactId>log4j-api</artifactId>
                 <version>${log4j.version}</version>
-                <exclusions>
-                    <exclusion>
-                        <groupId>javax.mail</groupId>
-                        <artifactId>mail</artifactId>
-                    </exclusion>
-                    <exclusion>
-                        <groupId>javax.jms</groupId>
-                        <artifactId>jms</artifactId>
-                    </exclusion>
-                    <exclusion>
-                        <groupId>com.sun.jdmk</groupId>
-                        <artifactId>jmxtools</artifactId>
-                    </exclusion>
-                    <exclusion>
-                        <groupId>com.sun.jmx</groupId>
-                        <artifactId>jmxri</artifactId>
-                    </exclusion>
-                </exclusions>
+            </dependency>
+            <dependency>
+                <groupId>org.apache.logging.log4j</groupId>
+                <artifactId>log4j-core</artifactId>
+                <version>${log4j.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.apache.logging.log4j</groupId>
+                <artifactId>log4j-to-slf4j</artifactId>
+                <version>${log4j.version}</version>
             </dependency>
             <dependency>
                 <groupId>org.testng</groupId>
@@ -143,10 +135,10 @@
         </dependencies>
     </dependencyManagement>
     <scm>
-        <connection>scm:git:https://github.com/wso2-extensions/siddhi-store-elasticsearch.git</connection>
-        <url>https://github.com/wso2-extensions/siddhi-store-elasticsearch.git</url>
-        <developerConnection>scm:git:https://github.com/wso2-extensions/siddhi-store-elasticsearch.git</developerConnection>
-        <tag>v2.1.1</tag>
+        <connection>scm:git:https://github.com/siddhi-io/siddhi-store-elasticsearch.git</connection>
+        <url>https://github.com/siddhi-io/siddhi-store-elasticsearch.git</url>
+        <developerConnection>scm:git:https://github.com/siddhi-io/siddhi-store-elasticsearch.git</developerConnection>
+        <tag>HEAD</tag>
     </scm>
     <build>
         <plugins>
@@ -205,12 +197,13 @@
         <commons.codec.version>1.10</commons.codec.version>
         <commons.logging.version>1.2</commons.logging.version>
         <commons.logging.version.range>(1.2,2)</commons.logging.version.range>
-        <log4j.version>1.2.17.wso2v1</log4j.version>
+        <log4j.version>2.11.1</log4j.version>
         <carbon.transport.version>4.4.15</carbon.transport.version>
         <siddhi.map.json.version>4.0.29</siddhi.map.json.version>
         <siddhi.map.xml.version>4.0.16</siddhi.map.xml.version>
         <jacoco.plugin.version>0.7.9</jacoco.plugin.version>
         <carbon.feature.plugin.version>3.0.0</carbon.feature.plugin.version>
         <io.fabric8.version>0.20.0</io.fabric8.version>
+        <maven.findbugsplugin.version>3.0.5</maven.findbugsplugin.version>
     </properties>
 </project>


### PR DESCRIPTION
## Purpose
This update introduces the following configurations as annotations or YAML-level extensions to control timeout values for Elasticsearch server requests.

- `index.request.timeout`
  - Timeout to wait for the all the nodes to acknowledge the index-related operations in seconds.
  - Supported Request Types: CreateIndexRequest
- `index.request.master.timeout`
  - Timeout to connect to the master node for index-related operations in seconds.
  - Supported Request Types: CreateIndexRequest
- `bulk.request.timeout`
  - Timeout to wait for the bulk request to be performed in seconds.
  - Supported Request Types: BulkRequest (IndexRequest, DeleteRequest, UpdateRequest)

## Related Issue
- https://github.com/wso2/product-is/issues/21810